### PR TITLE
set the DEV_CLI_BIN_PATH env var only for the duration of the execution of the binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev",
   "type": "module",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "",
   "dependencies": {
     "colors": "^1.4.0",

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -1,6 +1,4 @@
 <$SHELL_FN_NAME$>() {
-  export DEV_CLI_BIN_PATH="<$SHELL_BIN_PATH$>"
-
   local tempfile exitcode cmd
 
   tempfile="$(mktemp -u)"
@@ -8,7 +6,7 @@
   exec 8<"${tempfile}"
   rm -f "${tempfile}"
 
-  <$SHELL_BIN_PATH$> "$@"
+  DEV_CLI_BIN_PATH="<$SHELL_BIN_PATH$>" <$SHELL_BIN_PATH$> "$@"
   exitcode=$?
 
   while read -r cmd; do


### PR DESCRIPTION
this is to make sure running `dev` by itself detects if the shell module is installed in that specific execution of `dev.