### PR TITLE
Add install script for fish shell

### DIFF
--- a/shell/index.mjs
+++ b/shell/index.mjs
@@ -81,7 +81,12 @@ export const run = async ({ config, writeConfig, args }) => {
 
       console.log(script);
     } else if (shellType === "fish") {
-      console.log(/* fish script */);
+      const script = fs
+        .readFileSync(path.join(__dirname, "./install.fish"), "utf8")
+        .replaceAll("<$SHELL_FN_NAME$>", functionName)
+        .replaceAll("<$SHELL_BIN_PATH$>", binaryPath);
+
+      console.log(script);
     }
 
     return;

--- a/shell/install.fish
+++ b/shell/install.fish
@@ -1,0 +1,23 @@
+function <$SHELL_FN_NAME$>
+    set -l tempfile (mktemp -u)
+    exec 9>$tempfile
+    exec 8<$tempfile
+    rm -f $tempfile
+  
+    set DEV_CLI_BIN_PATH <$SHELL_BIN_PATH$> <$SHELL_BIN_PATH$> $argv
+    set -l exitcode $status
+  
+    while read cmd
+        switch $cmd
+            case "cd:*"
+               cd (string replace -r "cd:" "" -- $cmd)
+            case "*"
+               # echo do nothing
+        end
+    end <&8
+  
+    exec 8<&-
+    exec 9<&-
+  
+    return $exitcode
+end


### PR DESCRIPTION
Apparently, running `exec` without any argument is not support by fish (fish-shell/fish-shell#3948). So, the script does not work right now.