### PR TITLE
include all branches and tags by default when using dev clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ You can also [customize the name of the function](https://github.com/amir-s/dev/
   If `dev` needs to `cd` into the cloned project after it is done.
 - `clone.ssh` (default: `true`)
   If `dev` is needs craft the remote url via `ssh` when a short format repo (example: `amir-s/dev`) is provided. If set to `false`, it'll use `https`.
+- `clone.branch.single` (default: `false`)
+  If `--single-branch` should be passed to `git clone`.
+- `clone.depth` (default: `null`)
+  If `--depth <number>` should be passed to `git clone`. Set the config to the `<number>` you desire.
+- `clone.tags` (default: `true`)
+  If set to `false` then `--no-tags` will be provided to `git clone`.
 
 ### `dev open pr`
 

--- a/clone/index.mjs
+++ b/clone/index.mjs
@@ -107,6 +107,9 @@ export const run = async ({ config, args, cd }) => {
   const path = config("clone.path", "<home>/src/<org>/<user>/<repo>");
   const changeDirectory = config("clone.cd", true);
   const ssh = config("clone.ssh", true);
+  const singleBranch = config("clone.branch.single", false);
+  const depth = config("clone.depth", null);
+  const tags = config("clone.tags", true);
 
   if (args.length === 0) {
     help.generic();
@@ -137,11 +140,15 @@ export const run = async ({ config, args, cd }) => {
     return;
   }
 
+  const singleBranchArg = singleBranch ? "--single-branch" : "";
+  const depthArg = depth !== null ? `--depth ${depth}` : "";
+  const tagsArg = tags ? "" : "--no-tags";
+
   const result = await spinner(
     `cloning ${user}/${repo} into ${clonePath}`,
     async () => {
       return await nothrow(
-        $`git clone --depth 1 --single-branch --no-tags ${remote} ${clonePath}`
+        $`git clone ${depthArg} ${singleBranchArg} ${tagsArg} ${remote} ${clonePath}`
       );
     }
   );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev",
   "type": "module",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "",
   "dependencies": {
     "arpjs": "^1.2.0",


### PR DESCRIPTION
remove `--single-branch` and `--no-tags` and `--depth 1` from `git clone` when running `dev clone`.
expose config variables if to include those arguments.