### PR TITLE
Better `dev cd` fuzzy matching + tests

### DIFF
--- a/cd/index.mjs
+++ b/cd/index.mjs
@@ -9,6 +9,24 @@ const shellModuleInstalled = () => {
   return !!process.env["DEV_CLI_BIN_PATH"];
 };
 
+export const findMatch = (allRepos, requestedString) => {
+  return allRepos.reduce(
+    (candidate, repo) => {
+      const closeness = stringCloseness(
+        `${repo.user}${repo.repo}`.toLocaleLowerCase(),
+        requestedString
+      );
+
+      if (closeness > candidate.closeness) return { closeness, repo };
+      return candidate;
+    },
+    {
+      closeness: -Infinity,
+      repo: null,
+    }
+  );
+};
+
 export const run = async ({ config, args, cd }) => {
   if (!shellModuleInstalled()) {
     report.error("shell module is not installed.");
@@ -57,20 +75,8 @@ export const run = async ({ config, args, cd }) => {
     .filter((x) => x);
 
   const requestedString = args.join("").toLocaleLowerCase();
-  const matched = allRepos.reduce(
-    (candidate, repo) => {
-      const closeness = stringCloseness(
-        `${repo.user}${repo.repo}`.toLocaleLowerCase(),
-        requestedString
-      );
-      if (closeness > candidate.closeness) return { closeness, repo };
-      return candidate;
-    },
-    {
-      closeness: -Infinity,
-      repo: null,
-    }
-  );
+
+  const matched = findMatch(allRepos, requestedString);
 
   if (!matched.repo) {
     report.error(`no repo found for ${args.join(" ")}`);

--- a/cd/index.mjs
+++ b/cd/index.mjs
@@ -12,10 +12,21 @@ const shellModuleInstalled = () => {
 export const findMatch = (allRepos, requestedString) => {
   return allRepos.reduce(
     (candidate, repo) => {
-      const closeness = stringCloseness(
+      // calculate closeness for both full path and repo name
+      // we get the maximum of the two and add 1 if both are > 0 to give a slight preference
+      // to strings that match both the full path and the repo name
+
+      const fullPathCloseness = stringCloseness(
         `${repo.user}${repo.repo}`.toLocaleLowerCase(),
         requestedString
       );
+      const repoNameCloseness = stringCloseness(
+        `${repo.repo}`.toLocaleLowerCase(),
+        requestedString
+      );
+
+      let closeness = Math.max(fullPathCloseness, repoNameCloseness);
+      if (fullPathCloseness > 0 && repoNameCloseness > 0) closeness += 1;
 
       if (closeness > candidate.closeness) return { closeness, repo };
       return candidate;

--- a/cd/tests/index.test.mjs
+++ b/cd/tests/index.test.mjs
@@ -35,4 +35,38 @@ describe("findMatch", () => {
     );
     assert.deepEqual({ user: "amir-s", repo: "123abc1230" }, repo);
   });
+
+  test("prefers repo and query to have continues matches", () => {
+    const { repo } = findMatch(
+      [
+        {
+          user: "star",
+          repo: "aba",
+        },
+        {
+          user: "amir-s",
+          repo: "saba",
+        },
+      ],
+      "saba"
+    );
+    assert.deepEqual({ user: "amir-s", repo: "saba" }, repo);
+  });
+
+  test("prefers repo and query to match both repo and user somehow", () => {
+    const { repo } = findMatch(
+      [
+        {
+          user: "str-blah",
+          repo: "blah-blah",
+        },
+        {
+          user: "str-blah",
+          repo: "blah-str-blah",
+        },
+      ],
+      "str"
+    );
+    assert.deepEqual({ user: "str-blah", repo: "blah-str-blah" }, repo);
+  });
 });

--- a/cd/tests/index.test.mjs
+++ b/cd/tests/index.test.mjs
@@ -1,0 +1,38 @@
+import assert from "assert";
+import { findMatch } from "../index.mjs";
+
+describe("findMatch", () => {
+  test("prefers repo and query to share the first letter", () => {
+    const { repo } = findMatch(
+      [
+        {
+          user: "0amir-s",
+          repo: "123abc123",
+        },
+        {
+          user: "amir-s",
+          repo: "123abc123",
+        },
+      ],
+      "a1abc"
+    );
+    assert.deepEqual({ user: "amir-s", repo: "123abc123" }, repo);
+  });
+
+  test("prefers repo and query to share the last letter", () => {
+    const { repo } = findMatch(
+      [
+        {
+          user: "amir-s",
+          repo: "123abc1203",
+        },
+        {
+          user: "amir-s",
+          repo: "123abc1230",
+        },
+      ],
+      "abc0"
+    );
+    assert.deepEqual({ user: "amir-s", repo: "123abc1230" }, repo);
+  });
+});

--- a/clone/tests/index.test.mjs
+++ b/clone/tests/index.test.mjs
@@ -51,25 +51,28 @@ const tests = {
     remote: "https://git.somewhere.co.uk/one-1/~two/Three/user/repo",
   },
 };
-Object.keys(tests).forEach((url) => {
-  const testcase = tests[url];
-  test(`parseArgument ${url}`, () => {
-    const { org, user, repo, remote } = parseArgument(url, { ssh: true });
-    assert.deepEqual({ org, user, repo, remote }, testcase);
-  });
-});
 
-test("parseArgument with ssh=false", () => {
-  const { org, user, repo, remote } = parseArgument("amir-s/dev.git", {
-    ssh: false,
+describe("parseArgument", () => {
+  Object.keys(tests).forEach((url) => {
+    const testcase = tests[url];
+    test(url, () => {
+      const { org, user, repo, remote } = parseArgument(url, { ssh: true });
+      assert.deepEqual({ org, user, repo, remote }, testcase);
+    });
   });
-  assert.deepEqual(
-    { org, user, repo, remote },
-    {
-      org: "github.com",
-      user: "amir-s",
-      repo: "dev",
-      remote: "https://github.com/amir-s/dev.git",
-    }
-  );
+
+  test("with ssh=false", () => {
+    const { org, user, repo, remote } = parseArgument("amir-s/dev.git", {
+      ssh: false,
+    });
+    assert.deepEqual(
+      { org, user, repo, remote },
+      {
+        org: "github.com",
+        user: "amir-s",
+        repo: "dev",
+        remote: "https://github.com/amir-s/dev.git",
+      }
+    );
+  });
 });

--- a/internals/index.mjs
+++ b/internals/index.mjs
@@ -3,10 +3,17 @@ export const stringCloseness = (str, q) => {
 
   let score = 0;
   let index = 0;
+
+  let continuesScore = -0.5;
+
   for (let i = 0; i < q.length; i++) {
     while (index < str.length && str[index] !== q[i]) {
       index++;
+      continuesScore = -0.5;
     }
+
+    continuesScore += 0.5;
+    score += continuesScore;
 
     if (index === 0) score += 2;
     if (index === str.length - 1) score += 1;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev",
   "type": "module",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "",
   "dependencies": {
     "arpjs": "^1.2.0",

--- a/test.mjs
+++ b/test.mjs
@@ -2,21 +2,31 @@ import path from "path";
 import report from "yurnalist";
 
 const tests = [];
-
+let testNamePrefix = "";
 function test(name, fn) {
-  tests.push({ name, fn });
+  tests.push({
+    prefix: testNamePrefix,
+    name,
+    fn,
+  });
+}
+
+function describe(name, fn) {
+  testNamePrefix = name;
+  fn();
+  testNamePrefix = "";
 }
 
 const failed = [];
 
 async function run() {
-  for (const { name, fn } of tests) {
+  for (const { prefix, name, fn } of tests) {
     try {
       await fn();
-      report.success(`${name} ✅`);
+      report.success(`${prefix ? `${prefix.blue} ` : ""}${name} ✅`);
     } catch (e) {
-      failed.push({ name, e });
-      report.error(`${name} 💥`);
+      failed.push({ prefix, name, e });
+      report.error(`${prefix ? `${prefix.blue} ` : ""}${name} 💥`);
     }
   }
 }
@@ -24,6 +34,7 @@ async function run() {
 const files = process.argv.slice(2);
 
 global.test = test;
+global.describe = describe;
 
 async function runFiles() {
   for (const file of files) {
@@ -37,8 +48,8 @@ runFiles()
     if (failed.length > 0) {
       console.log("\n\n\n\n");
       report.info(`${failed.length} test(s) failed:\n`);
-      failed.forEach(({ name, e }) => {
-        report.error(`${name}`);
+      failed.forEach(({ prefix, name, e }) => {
+        report.error(`${prefix ? `${prefix.blue} ` : ""}${name}`);
         report.error(e);
         console.log("\n");
       });


### PR DESCRIPTION
Fixed a problem I've been having with the fuzzy matching picking the wrong repo when used with `dev cd`.
Now it prioritizes repos where the passed string is found in them mostly in the continuous form.
Plus, it tries to match the string with repo name with and without the user name (`amir-s/dev` and `dev`).
Also, gives slight advantage to repos that both scenarios ^ are somehow are matched.