### PR TITLE
add host to known_hosts for clone via ssh

### DIFF
--- a/contextual/index.mjs
+++ b/contextual/index.mjs
@@ -1,4 +1,4 @@
-import { $, nothrow } from "zx";
+import { $ } from "zx";
 
 $.verbose = true;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev",
   "type": "module",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "",
   "dependencies": {
     "arpjs": "^1.2.0",

--- a/utils/knownhosts.mjs
+++ b/utils/knownhosts.mjs
@@ -1,0 +1,11 @@
+import fs from "fs";
+import path from "path";
+import { $, os } from "zx";
+
+const KNOWN_HOSTS_PATH = path.resolve(os.homedir(), ".ssh", "known_hosts");
+
+export const isKnownHost = (host) => {
+  if (!fs.existsSync(KNOWN_HOSTS_PATH)) return false;
+  const knownHosts = fs.readFileSync(KNOWN_HOSTS_PATH, "utf8").split("\n");
+  return knownHosts.some((entry) => entry.split(" ")[0] === host);
+};


### PR DESCRIPTION
Fix #14 

Conditionally run `ssh-keyscan` for hosts that are not known already if `dev clone`ing via `ssh`.