### PR TITLE
include all ts files when compiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,11 @@ jobs:
 
       - name: Build for ${{ matrix.os }}-${{ matrix.architecture }}
         run: |
-          deno compile -A --target ${{ matrix.target }} --output dev-${{ matrix.os }}-${{ matrix.architecture }} main.ts
+          # Find all .ts files in modules/ and construct include flags in a single line
+          INCLUDES=$(find modules -type f -name "*.ts" -exec echo --include={} \; | xargs)
+
+          # Compile with dynamically constructed include flags
+          deno compile -A $INCLUDES --target ${{ matrix.target }} --output dev-${{ matrix.os }}-${{ matrix.architecture }} main.ts
 
       - name: Upload binary as artifact
         uses: actions/upload-artifact@v3

--- a/modules/_cd/index.ts
+++ b/modules/_cd/index.ts
@@ -1,3 +1,4 @@
+import "colors";
 import { $ } from "zx";
 import report from "yurnalist";
 import inquirer from "inquirer";


### PR DESCRIPTION
`dev help` doesn't list all the help commands since it loads the available helps automatically. 
all files either need to be statically imported from the entry points, or we have to pass `--include <path to ts file>` for each ts file.
so we're doing the latter, as importing everything in the entry point might slow things down on the run time.