### PR TITLE
fix(create): avoid logging during clone spinner

### DIFF
--- a/modules/clone/index.ts
+++ b/modules/clone/index.ts
@@ -144,19 +144,17 @@ export const run = async ({ config, args, cd }: ModuleRunOptions) => {
 
   if (ssh && !isKnownHost(org)) {
     report.warn(`using ssh but ${org} is not in the known hosts.`);
+    report.command(`ssh-keyscan ${org} >> ~/.ssh/known_hosts`);
     await spinner(`adding ${org} to known hosts`, async () => {
-      report.command(`ssh-keyscan ${org} >> ~/.ssh/known_hosts`);
       await $`ssh-keyscan ${org} >> ~/.ssh/known_hosts`;
     });
   }
 
+  const forwardedArgs = args.slice(1);
+  report.command(`git clone ${forwardedArgs.join(" ")} ${remote} ${clonePath}`);
   const result = await spinner(
     `cloning ${user}/${repo} into ${clonePath}`,
     async () => {
-      const forwardedArgs = args.slice(1);
-      report.command(
-        `git clone ${forwardedArgs.join(" ")} ${remote} ${clonePath}`,
-      );
       return await $`git clone ${forwardedArgs} ${remote} ${clonePath}`
         .nothrow();
     },

--- a/utils/spinner.ts
+++ b/utils/spinner.ts
@@ -7,11 +7,8 @@ export const spinner = async <T>(
   const spinner = report.activity();
   spinner.tick(title);
   try {
-    const result = await fn();
+    return await fn();
+  } finally {
     spinner.end();
-    return result;
-  } catch (err) {
-    spinner.end();
-    throw err;
   }
 };


### PR DESCRIPTION
## Summary
- move clone command logging outside active yurnalist spinners
- ensure spinner cleanup always runs through finally

## Verification
- deno task test
- deno lint
- deno fmt --check
- rebuilt a compiled binary and exercised the create prompt flow with fake gh/git executables

## Issue
- No issue number was provided.